### PR TITLE
Add AdSense verification index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="google-adsense-account" content="ca-pub-1142089868889766">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Google AdSense Verification</title>
+</head>
+<body>
+    <h1>Google AdSense Verification Page</h1>
+    <p>This page is set up for AdSense verification.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple index page with required Google AdSense meta tag for account verification

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f829d7c08332a701c2f18b05a682