### PR TITLE
Ensure sitemap is served as static XML

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll processing on GitHub Pages

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset
-  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+  xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <url>
     <loc>https://bbibbubbang.github.io/</loc>
-    <lastmod>2024-05-28T00:00:00+00:00</lastmod>
+    <lastmod>2024-05-28T00:00:00Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- disable the Jekyll build pipeline so the sitemap is served exactly as written
- update the sitemap namespaces and timestamp format to align with standard XML expectations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc20acb89483328dce7da88ba27e7a